### PR TITLE
SIM-10249: Fix OAuth Token for Windows Event Collection

### DIFF
--- a/get-oauth-token.ps1
+++ b/get-oauth-token.ps1
@@ -1,19 +1,14 @@
 param ([string] $ControllerUrl, [string] $AccountName, [string] $ApiClient, [string] $ApiSecret)
 
 $Uri = "$($ControllerUrl)/controller/api/oauth/access_token"
-
-$Headers = @{
-    'Content-Type' = 'application/vnd.appd.cntrl+protobuf;v=1'
-}
-
+$Headers = @{ 'Content-Type' = 'application/x-www-form-urlencoded' }
 $Data = "grant_type=client_credentials&client_id=$($ApiClient)@$($AccountName)&client_secret=$($ApiSecret)"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 try {
-$Response = Invoke-RestMethod -Uri $Uri -Method POST -Headers $Headers -Body $Data
-
-$Response.access_token
-
-} catch { 
+    $Response = Invoke-RestMethod -Uri $Uri -Method POST -Headers $Headers -Body $Data
+    return $Response.access_token
+} catch {
+    Write-Host "[WindowsEvents] OAuth token fetch failed: $_"
+    return $null
 }
-


### PR DESCRIPTION
Changes Made:

- get-oauth-token.ps1: Switched POST to standard application/x-www-form-urlencoded and now logs/returns null on failures.
- get-wmi-metrics.ps1: Added a minimal Log helper; reduced log chatter to “start”, events=<count>, posted=<count>, “done”; still handles lastRun, event retrieval via get-winevent.ps1, OAuth, posting to the custom event endpoint, and persists lastRun. No logic changes beyond logging.

Test Results:
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/fd8ab318-4f4f-41f7-8dd1-195254c00da9" />
